### PR TITLE
Use string substitution and shell redirection that works with dash.

### DIFF
--- a/configure
+++ b/configure
@@ -3,16 +3,17 @@ set -e
 unset GCC
 
 while [ $# -gt 0 ] ; do
-    if [ "${1:0:11}" = "--with-gcc=" ] ; then
-        GCC=${1:11}
+    maybe_gcc=${1#--with-gcc=}
+    if [ "$maybe_gcc" != "$1" ]; then
+        GCC=$maybe_gcc
     fi
     shift
 done
 
 rm -f foreign-jni.buildinfo
 
-if ! echo '#include <jni.h>' | $GCC -E - &> /dev/null ; then
-    JNI_GCC_INCLUDES=$"-I${JAVA_HOME}/include/"
+if ! echo '#include <jni.h>' | $GCC -E - 2>&1 > /dev/null ; then
+    JNI_GCC_INCLUDES="-I${JAVA_HOME}/include/"
     if [ -d "${JAVA_HOME}/include/linux" ] ; then
         JNI_GCC_INCLUDES="$JNI_GCC_INCLUDES -I${JAVA_HOME}/include/linux/"
     fi
@@ -22,8 +23,8 @@ if ! echo '#include <jni.h>' | $GCC -E - &> /dev/null ; then
     if [ -d "${JAVA_HOME}/include/win32" ] ; then
         JNI_GCC_INCLUDES="$JNI_GCC_INCLUDES -I${JAVA_HOME}/include/win32/"
     fi
-    if ! echo '#include <jni.h>' | $GCC ${JNI_GCC_INCLUDES} -E - &> /dev/null ; then
-        echo "Include file jni.h not found! Please set $JAVA_HOME or install jni.h in your compiler include path."
+    if ! echo '#include <jni.h>' | $GCC ${JNI_GCC_INCLUDES} -E - 2>&1 > /dev/null ; then
+        echo "Include file jni.h not found! Please set \$JAVA_HOME or install jni.h in your compiler include path."
         exit 1
     else
         echo cc-options: ${JNI_GCC_INCLUDES} >> foreign-jni.buildinfo


### PR DESCRIPTION
Despite the shebang line, this script is invoked by cabal using sh. The default shell on Ubuntu, dash, does not understand bash-isms like ${p:n:m}.
